### PR TITLE
feat(admin): Make folder type editable in admin and support dot in fo…

### DIFF
--- a/sage_mailbox/admin/mailbox.py
+++ b/sage_mailbox/admin/mailbox.py
@@ -37,7 +37,7 @@ class MailboxAdmin(admin.ModelAdmin):
         (None, {"fields": ("name", "slug", "folder_type")}),
         (_("Change Log"), {"fields": ("created_at", "modified_at")}),
     )
-    readonly_fields = ("folder_type", "created_at", "modified_at")
+    readonly_fields = ("created_at", "modified_at")
     actions = [delete_selected]
 
     def get_readonly_fields(self, request, obj=None):

--- a/sage_mailbox/validators.py
+++ b/sage_mailbox/validators.py
@@ -19,10 +19,10 @@ class FolderNameValidator:
     """
 
     length_error_message = "Folder name must be between 1 and 255 characters long."
-    character_error_message = "Folder name contains invalid characters. Allowed characters are letters, numbers, underscore, and hyphen. Spaces are not allowed."
+    character_error_message = "Folder name contains invalid characters. Allowed characters are letters, numbers, underscore, hyphen, and dot. Spaces are not allowed."
     code_length = "folder_name_length"
     code_character = "folder_name_invalid_character"
-    regex = re.compile(r"^[\w-]+$")
+    regex = re.compile(r"^[\w.-]+$")
 
     def __call__(self, value):
         if not (1 <= len(value) <= 255):


### PR DESCRIPTION
…lder names

Updated the Mailbox admin configuration to make the `folder_type` field editable directly from the admin interface, improving the usability for administrators managing mailbox configurations.

Additionally, modified the `FolderNameValidator` to support dots (`.`) in folder names. This enhancement allows more flexibility in naming conventions while maintaining the existing validation rules (length and character restrictions).

closes #13.