### PR TITLE
feat(Mailbox): Integrate django-autoslug and update Mailbox model with AutoSlugField

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -534,6 +534,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-autoslug"
+version = "1.9.9"
+description = "An automated slug field for Django."
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-autoslug-1.9.9.tar.gz", hash = "sha256:79f88e9433c1c88d8d3f2bec60d65ca98bffaff6c072b78aa5fd99d0e84a13dd"},
+    {file = "django_autoslug-1.9.9-py2.py3-none-any.whl", hash = "sha256:81cb018944498f27f439d439687cf902212cafbdb8c74c8ca0307543a3d82907"},
+]
+
+[package.extras]
+cyrillic = ["pytils (>=0.2)"]
+translitcodec = ["translitcodec (>=0.3)"]
+
+[[package]]
 name = "django-jsonform"
 version = "2.22.0"
 description = "A user-friendly JSON editing form for Django admin."
@@ -1916,4 +1931,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "0563b93797d621f84ef2d36fa1fd091de94f4e1138c8919b1e2ccd53b7838459"
+content-hash = "65730f7976c42ce589e669b79b9f6a305c1f9c082b47158c7ca08282f07227a7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ django = "^5.0.7"
 python-sage-imap = "^0.4.2"
 django-jsonform = "^2.22.0"
 python-dateutil = "^2.9.0.post0"
+django-autoslug = "^1.9.9"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/sage_mailbox/admin/mailbox.py
+++ b/sage_mailbox/admin/mailbox.py
@@ -40,7 +40,7 @@ class MailboxAdmin(admin.ModelAdmin):
         (None, {"fields": ("name", "slug", "folder_type")}),
         (_("Change Log"), {"fields": ("created_at", "modified_at")}),
     )
-    readonly_fields = ("created_at", "modified_at")
+    readonly_fields = ("created_at", "modified_at", "slug")
     actions = [delete_selected]
 
     def get_readonly_fields(self, request, obj=None):

--- a/sage_mailbox/admin/mailbox.py
+++ b/sage_mailbox/admin/mailbox.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.http.response import HttpResponse
 from django.urls import path, reverse
 from django.utils.translation import gettext_lazy as _
+
 from sage_imap.exceptions import (
     IMAPFolderExistsError,
     IMAPFolderNotFoundError,
@@ -19,6 +20,7 @@ from sage_imap.services import IMAPClient, IMAPFolderService
 from sage_mailbox.admin.actions import delete_selected
 from sage_mailbox.models.mailbox import Mailbox, StandardMailboxNames
 
+# IMAP configuration
 imap_host = getattr(settings, 'IMAP_SERVER_DOMAIN', None)
 imap_username = getattr(settings, 'IMAP_SERVER_USER', None)
 imap_password = getattr(settings, 'IMAP_SERVER_PASSWORD', None)
@@ -27,8 +29,9 @@ imap_password = getattr(settings, 'IMAP_SERVER_PASSWORD', None)
 @admin.register(Mailbox)
 class MailboxAdmin(admin.ModelAdmin):
     change_list_template = "admin/mailbox/change_list.html"
-
-    list_display = ("name", "slug", "folder_type", "created_at", "modified_at")
+    list_display = (
+        "name", "slug", "folder_type", "created_at", "modified_at"
+    )
     search_fields = ("name",)
     ordering = ("name",)
     list_per_page = 25
@@ -75,7 +78,8 @@ class MailboxAdmin(admin.ModelAdmin):
                             raise ValidationError(str(e))
                     super().save_model(request, obj, form, change)
                 messages.success(
-                    request, f'The Mailbox "{new_name}" was added successfully.'
+                    request,
+                    f'The Mailbox "{new_name}" was added successfully.'
                 )
         except ValidationError as e:
             messages.error(request, f"Error: {e.message}")
@@ -101,11 +105,11 @@ class MailboxAdmin(admin.ModelAdmin):
                     try:
                         folder_service.delete_folder(obj.name)
                     except IMAPFolderNotFoundError:
-                        # If folder is not found on IMAP, delete only in Django
                         super().delete_model(request, obj)
                         messages.warning(
                             request,
-                            f'The Mailbox "{obj.name}" was deleted from admin, but it did not exist on the IMAP server.',
+                            f'The Mailbox "{obj.name}" was deleted from admin, '
+                            'but it did not exist on the IMAP server.'
                         )
                     except IMAPFolderOperationError as e:
                         raise ValidationError(str(e))
@@ -113,7 +117,8 @@ class MailboxAdmin(admin.ModelAdmin):
                         super().delete_model(request, obj)
                         messages.success(
                             request,
-                            f'The Mailbox "{obj.name}" was deleted successfully from both admin and IMAP server.',
+                            f'The Mailbox "{obj.name}" was deleted successfully '
+                            'from both admin and IMAP server.'
                         )
         except ValidationError as e:
             messages.error(request, f"Error: {e.message}")
@@ -129,11 +134,11 @@ class MailboxAdmin(admin.ModelAdmin):
                         try:
                             folder_service.delete_folder(obj.name)
                         except IMAPFolderNotFoundError:
-                            # If folder is not found on IMAP, delete only in Django
                             super().delete_model(request, obj)
                             messages.warning(
                                 request,
-                                f'The mailbox "{obj.name}" was deleted from admin, but it did not exist on the IMAP server.',
+                                f'The mailbox "{obj.name}" was deleted from admin, '
+                                'but it did not exist on the IMAP server.'
                             )
                         except IMAPFolderOperationError as e:
                             raise ValidationError(str(e))
@@ -142,7 +147,8 @@ class MailboxAdmin(admin.ModelAdmin):
                     super().delete_queryset(request, queryset)
                 messages.success(
                     request,
-                    "The selected Mailboxes were deleted successfully from both admin and IMAP server.",
+                    "The selected Mailboxes were deleted successfully "
+                    "from both admin and IMAP server."
                 )
         except ValidationError as e:
             messages.error(request, f"Error: {e.message}")
@@ -150,22 +156,43 @@ class MailboxAdmin(admin.ModelAdmin):
             messages.error(request, f"Unexpected error: {str(e)}")
 
     def response_add(self, request, obj, post_url_continue=None):
+        """
+        Handles the HTTP response after adding a new object in the Django admin.
+
+        This method is overridden to prevent the double flash message issue
+        that can occur in Django's admin interface.
+        """
         if "_continue" in request.POST:
             return super().response_add(request, obj, post_url_continue)
         elif "_addanother" in request.POST:
             return HttpResponseRedirect(request.path)
-        else:
-            return HttpResponseRedirect(self.get_success_url(request, obj))
+        elif "_save" in request.POST:
+            post_url = reverse(
+                "admin:%s_%s_changelist" % (self.opts.app_label, self.opts.model_name),
+                current_app=self.admin_site.name,
+            )
+            return HttpResponseRedirect(post_url)
+        return HttpResponseRedirect(self.get_success_url(request, obj))
 
     def response_change(self, request, obj):
+        """
+        Handles the HTTP response after changing an existing object in the Django admin.
+
+        Similar to `response_add`, this method prevents the issue of double flash messages.
+        """
         if "_continue" in request.POST:
             return super().response_change(request, obj)
         elif "_saveasnew" in request.POST:
             return super().response_add(request, obj)
         elif "_addanother" in request.POST:
             return HttpResponseRedirect(request.path)
-        else:
-            return HttpResponseRedirect(self.get_success_url(request, obj))
+        elif "_save" in request.POST:
+            post_url = reverse(
+                "admin:%s_%s_changelist" % (self.opts.app_label, self.opts.model_name),
+                current_app=self.admin_site.name,
+            )
+            return HttpResponseRedirect(post_url)
+        return HttpResponseRedirect(self.get_success_url(request, obj))
 
     def response_delete(
         self, request: HttpRequest, obj_display: str, obj_id: int
@@ -180,13 +207,17 @@ class MailboxAdmin(admin.ModelAdmin):
         return request.META.get("HTTP_REFERER", "/admin/")
 
     def sync_folders(self, request):
+        """
+        Synchronizes the mailboxes between the IMAP server and the Django admin.
+        """
         try:
             with IMAPClient(imap_host, imap_username, imap_password) as client:
                 folder_service = IMAPFolderService(client)
                 folders = folder_service.list_folders()
                 for folder_name in folders:
                     Mailbox.objects.update_or_create(
-                        name=folder_name, defaults={"slug": folder_name.lower()}
+                        name=folder_name,
+                        defaults={"slug": folder_name.lower()}
                     )
                 messages.success(request, "Mailboxes synchronized successfully.")
         except Exception as e:
@@ -194,6 +225,6 @@ class MailboxAdmin(admin.ModelAdmin):
         return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
 
     def log_deletion(
-        self, request: HttpRequest, object: Any, object_repr: str
+        self, request: HttpRequest, obj: Any, object_repr: str
     ) -> LogEntry:
-        return super().log_deletion(request, object, object_repr)
+        return super().log_deletion(request, obj, object_repr)


### PR DESCRIPTION
- Added `django-autoslug` package to the project dependencies.
      - Updated `pyproject.toml` and `poetry.lock` to include the new package.

    - Modified `Mailbox` model in `sage_mailbox/models/mailbox.py`:
      - Replaced the existing slug field with `AutoSlugField` from `django-autoslug`.
      - Configured `AutoSlugField` to automatically convert periods (.) to hyphens (-) in slugs for better URL compatibility.

    - Updated `sage_mailbox/admin/mailbox.py`:
      - Ensured the admin interface reflects the changes in the `Mailbox` model, particularly the use of `AutoSlugField` for gener
ating slugs.

    closes #16.